### PR TITLE
Update resource-timing.ts to V2 of the spec

### DIFF
--- a/src/resource-timing.ts
+++ b/src/resource-timing.ts
@@ -2,7 +2,7 @@ import { performanceEntryStub } from "./performance-timeline";
 
 /**
  * The base stub for a PerformanceResourceTiming.
- * @see https://www.w3.org/TR/resource-timing-1/#performanceresourcetiming
+ * @see https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming
  */
 export const performanceResourceTimingStub = {
     // Extends PerformanceEntry and override the entryType from PerformanceEntry.
@@ -11,6 +11,8 @@ export const performanceResourceTimingStub = {
 
     // Properties defined by the spec.
     initiatorType: "",
+    nextHopProtocol: "",
+    workerStart: 0,
     redirectStart: 0,
     redirectEnd: 0,
     fetchStart: 0,
@@ -22,8 +24,9 @@ export const performanceResourceTimingStub = {
     requestStart: 0,
     responseStart: 0,
     responseEnd: 0,
-
-    // Serializer
+    transferSize: 0,
+    encodedBodySize: 0,
+    decodedBodySize: 0,
     toJSON: () => "",
 };
 


### PR DESCRIPTION
TypeScript types use the V2 spec, so this should too.